### PR TITLE
solucionado error de etiqueta div

### DIFF
--- a/prueba10_pokeapi.html
+++ b/prueba10_pokeapi.html
@@ -10,7 +10,7 @@
         <button id="buscar"> Buscar</button>
 
         <h2>Datos del pokemon: </h2>
-        <div id="datoPokemon"></textarea>
+        <div id="datoPokemon"></div>
     </body>
     <script src="prueba9_fetching.js"></script>
     <script>


### PR DESCRIPTION
Se detectó una etiqueta div mal cerrada que causaba errores de estructura en el DOM. Se corrigió el cierre en la línea correspondiente. No afecta a la lógica JavaScript.